### PR TITLE
Feat/sprint2 auth session

### DIFF
--- a/Proyecto/frontend/src/Lib/api.ts
+++ b/Proyecto/frontend/src/Lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Configura la URL base del backend desde una variable de entorno
-const baseURL = import.meta.env.VITE_API_URL ?? "http://localhost:4000/api";
+const baseURL = import.meta.env.VITE_API_URL ?? "http://localhost:4000";
 
 // Crea una instancia de Axios con la URL base
 export const api = axios.create({

--- a/Proyecto/frontend/src/Pages/Login/Login.tsx
+++ b/Proyecto/frontend/src/Pages/Login/Login.tsx
@@ -1,22 +1,53 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "../../Components/Navbar/Navbar";
 import styles from "./Login.module.css";
+import { useAuthStore } from "../../stores/authStore";
 
 export default function Login() {
 
-  /* Bloquea el scroll */
+  /* Bloquea el scroll del body mientras esta pantalla está activa */
   useEffect(() => {
     document.documentElement.classList.add("no-scroll");
     return () => document.documentElement.classList.remove("no-scroll");
   }, []);
 
+  /* Estado local de los inputs */
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [showPw, setShowPw] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  /* Store de auth: login (acción), loading y error */
+  const { login, loading, error } = useAuthStore();
+
+  /* Navegación y lectura de query (?next=/ruta) para redirigir tras login */
+  const navigate = useNavigate();
+  const [qs] = useSearchParams();
+  const next = qs.get("next") || "/profile";
+
+  /* Handler del botón Google: redirige al backend */
+  const handleGoogle = () => {
+    // en login no pasamos tdahType
+    window.location.href = "/auth/google";
+  };
+
+  /* Submit del formulario: llama al backend usando el store */
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: conectar con tu backend / provider
-    alert("Login demo (conecta tu auth aquí)");
+    try {
+      await login({ email, password }); // guarda {token,user} y setea Authorization en axios
+
+      // accedemos al user recién guardado en el store
+      const user = useAuthStore.getState().user;
+
+      // si viene ?next= lo respetamos, si no, mandamos según el rol
+      const target =
+      qs.get("next") || (user?.role === "admin" ? "/admin" : "/profile");
+
+      navigate(target, { replace: true }); // redirige a la ruta que venía en ?next o al home
+    } catch {
+      // El mensaje ya queda en `error` del store; aquí no hace falta más
+    }
   };
 
   return (
@@ -31,13 +62,21 @@ export default function Login() {
 
         {/* Card */}
         <div className={styles.card} role="form">
-          <button className={styles.googleBtn} type="button" onClick={() => alert("Google OAuth (demo)")}>
+          {/* Botón Google: delega el flujo al backend */}
+          <button
+            className={styles.googleBtn}
+            type="button"
+            onClick={handleGoogle}
+            disabled={loading}
+            aria-disabled={loading}
+          >
             <img src="/Images/google.png" alt="" aria-hidden className={styles.gIcon} />
             Google
           </button>
 
           <div className={styles.divider}><span>o</span></div>
 
+          {/* Formulario de credenciales */}
           <form onSubmit={handleSubmit} className={styles.form}>
             <label className={styles.inputWrap}>
               <input
@@ -46,6 +85,10 @@ export default function Login() {
                 required
                 className={styles.input}
                 autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={loading}
+                aria-disabled={loading}
               />
             </label>
 
@@ -56,19 +99,32 @@ export default function Login() {
                 required
                 className={styles.input}
                 autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={loading}
+                aria-disabled={loading}
               />
               <button
                 type="button"
                 className={styles.eyeBtn}
                 aria-label={showPw ? "Ocultar contraseña" : "Mostrar contraseña"}
                 onClick={() => setShowPw((v) => !v)}
+                disabled={loading}
               >
                 {showPw ? "🙈" : "👁️"}
               </button>
             </label>
 
-            <button type="submit" className={`${styles.pxBtn} ${styles.btnCyan}`}>
-              Continúa tu aventura!
+            {/* Mensaje de error del store (por ej.: 401) */}
+            {error && <p className={styles.error} role="alert">{error}</p>}
+
+            <button
+              type="submit"
+              className={`${styles.pxBtn} ${styles.btnCyan}`}
+              disabled={loading}
+              aria-busy={loading}
+            >
+              {loading ? "Iniciando..." : "¡Continúa tu aventura!"}
             </button>
           </form>
 

--- a/Proyecto/frontend/src/stores/appStore.ts
+++ b/Proyecto/frontend/src/stores/appStore.ts
@@ -30,6 +30,7 @@ export type User = {
   avatarUrl?: string;
   level?: number;
   xp?: number;
+  
   nextXp?: number;
   location?: string;
   work?: string;

--- a/Proyecto/frontend/src/stores/authStore.ts
+++ b/Proyecto/frontend/src/stores/authStore.ts
@@ -1,0 +1,111 @@
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import api from "../Lib/api";
+import { IUserSafe, TDAHType } from "../types/user";
+import { reviveUserDates } from "../utils/user_serializers";
+
+type RegisterBody = {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  tdahType?: TDAHType;
+};
+type LoginBody = { 
+    email: string; password: string
+};
+type AuthResponse = { token: string; user: any }; // llega con strings → lo revivimos
+
+type AuthState = {
+  user: IUserSafe | null;
+  token: string | null;
+  loading: boolean;
+  error: string | null;
+
+  setUser: (u: Partial<IUserSafe>) => void;
+  setSession: (token: string, user: IUserSafe) => void;
+  login: (body: LoginBody) => Promise<void>;
+  register: (body: RegisterBody) => Promise<void>;
+  logout: () => void;
+
+  acceptOAuthSession: (data: AuthResponse) => void;
+};
+
+const setAuthHeader = (token: string | null) => {
+  if (token) api.defaults.headers.common.Authorization = `Bearer ${token}`;
+  else delete api.defaults.headers.common.Authorization;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      token: null,
+      loading: false,
+      error: null,
+
+      setUser: (u) => {
+        const current = get().user;
+        if (!current) return;
+        set({ user: { ...current, ...u, streak: { ...current.streak, ...u.streak } } });
+      },
+
+      setSession: (token, user) => {
+        setAuthHeader(token);
+        set({ token, user, error: null });
+      },
+
+      register: async (body) => {
+        try {
+          set({ loading: true, error: null });
+          const { data } = await api.post<AuthResponse>("/auth/register", body);
+          const user = reviveUserDates(data.user);
+          get().setSession(data.token, user);
+        } catch (err: any) {
+          set({ error: err?.response?.data?.error ?? err?.message ?? "No se pudo registrar" });
+          throw err;
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      login: async (body) => {
+        try {
+          set({ loading: true, error: null });
+          const { data } = await api.post<AuthResponse>("/auth/login", body);
+          const user = reviveUserDates(data.user);
+          get().setSession(data.token, user);
+        } catch (err: any) {
+          set({ error: err?.response?.data?.error ?? err?.message ?? "No se pudo iniciar sesión" });
+          throw err;
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      logout: () => {
+        setAuthHeader(null);
+        set({ user: null, token: null, error: null, loading: false });
+      },
+
+      acceptOAuthSession: ({ token, user }) => {
+        // user llega con fechas string → revivir
+        const revived = reviveUserDates(user);
+        get().setSession(token, revived);
+      },
+    }),
+    {
+      name: "sq_auth",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ token: state.token, user: state.user }),
+      onRehydrateStorage: () => (state) => {
+        // reinyecta token y revive fechas post-hidratación
+        setAuthHeader(state?.token ?? null);
+        if (state?.user) {
+          state.user = reviveUserDates(state.user as any);
+        }
+      },
+    }
+  )
+);

--- a/Proyecto/frontend/src/types/user.ts
+++ b/Proyecto/frontend/src/types/user.ts
@@ -1,0 +1,20 @@
+export type Role = "student" | "admin";
+export type TDAHType = "inatento" | "hiperactivo" | "combinado" | null;
+
+export interface IUserSafe {
+  id: string;
+  name: string;
+  email: string;
+  username?: string;
+  avatarUrl?: string;
+  role: Role;
+  tdahType: TDAHType;
+
+  xp: number;
+  coins: number;
+  level: number;
+  streak: { count: number; lastCheck?: Date | null };
+  createdAt: Date;
+  updatedAt: Date;
+  lastLogin?: Date | null;
+}

--- a/Proyecto/frontend/src/utils/user_serializers.ts
+++ b/Proyecto/frontend/src/utils/user_serializers.ts
@@ -1,0 +1,14 @@
+import { IUserSafe } from "../types/user";
+
+export function reviveUserDates(u: any): IUserSafe {
+  return {
+    ...u,
+    createdAt: u.createdAt ? new Date(u.createdAt) : new Date(),
+    updatedAt: u.updatedAt ? new Date(u.updatedAt) : new Date(),
+    lastLogin: u?.lastLogin ? new Date(u.lastLogin) : null,
+    streak: {
+      count: u?.streak?.count ?? 0,
+      lastCheck: u?.streak?.lastCheck ? new Date(u.streak.lastCheck) : null,
+    },
+  };
+}


### PR DESCRIPTION
Este PR integra el **módulo de autenticación en frontend** y la configuración del cliente API para la plataforma **SynapQuest**:

## 🚀 API Client (`api.ts`)
- Configuración de `axios` con `baseURL`.
- Inyección automática del token JWT en el header `Authorization`.
- Interceptor para manejar respuestas `401 Unauthorized` (logout automático).

## 🔑 Login
- Conectado a `authStore.login` → llamada real a `/auth/login`.
- Manejo de estados `loading` y `error`.
- Redirección por rol: `/admin` para admins, `/profile` para estudiantes.
- Botón **Google OAuth** (flujo simple).

## 📝 Register
- Conectado a `authStore.register` → llamada real a `/auth/register`.
- Envío del `tdahType` elegido en el onboarding al backend.
- Redirección a `/profile/edit` tras el registro.
- Botón **Google OAuth** → pasa `tdahType` en la query (procesado como `state` en backend).

## 🔒 Sesión persistente
- `authStore` implementado con Zustand + localStorage.
- Rehidratación automática del token al recargar la app.
- Reinserción automática de `Authorization` en `axios`.